### PR TITLE
Replace 'inbox' with 'outbox' when appropriate

### DIFF
--- a/pub/database.go
+++ b/pub/database.go
@@ -101,13 +101,13 @@ type Database interface {
 	// at the specified IRI, for prepending new items.
 	//
 	// The library makes this call only after acquiring a lock first.
-	GetOutbox(c context.Context, inboxIRI *url.URL) (inbox vocab.ActivityStreamsOrderedCollectionPage, err error)
+	GetOutbox(c context.Context, outboxIRI *url.URL) (inbox vocab.ActivityStreamsOrderedCollectionPage, err error)
 	// SetOutbox saves the outbox value given from GetOutbox, with new items
 	// prepended. Note that the new items must not be added as independent
 	// database entries. Separate calls to Create will do that.
 	//
 	// The library makes this call only after acquiring a lock first.
-	SetOutbox(c context.Context, inbox vocab.ActivityStreamsOrderedCollectionPage) error
+	SetOutbox(c context.Context, outbox vocab.ActivityStreamsOrderedCollectionPage) error
 	// NewId creates a new IRI id for the provided activity or object. The
 	// implementation does not need to set the 'id' property and simply
 	// needs to determine the value.


### PR DESCRIPTION
As I was ~~wholesale copying~~ using the `database` interface definition
as a reference while creating my Federating implementation I noticed
some instances of a variable being named `inboxIRI` in an outbox method.