### PR TITLE
Fix: Use correct database method to get actor IRI

### DIFF
--- a/pub/social_wrapped_callbacks.go
+++ b/pub/social_wrapped_callbacks.go
@@ -458,7 +458,7 @@ func (w SocialWrappedCallbacks) like(c context.Context, a vocab.ActivityStreamsL
 		return err
 	}
 	// WARNING: Unlock not deferred.
-	actorIRI, err := w.db.ActorForInbox(c, w.outboxIRI)
+	actorIRI, err := w.db.ActorForOutbox(c, w.outboxIRI)
 	if err != nil {
 		w.db.Unlock(c, w.outboxIRI)
 		return err


### PR DESCRIPTION
Fix a small error where we need to get the actor IRI with outbox IRI in hand.