### PR TITLE
ensure host header is set

### DIFF
--- a/pub/transport.go
+++ b/pub/transport.go
@@ -5,12 +5,13 @@ import (
 	"context"
 	"crypto"
 	"fmt"
-	"github.com/go-fed/httpsig"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
 	"sync"
+
+	"github.com/go-fed/httpsig"
 )
 
 const (
@@ -118,6 +119,7 @@ func (h HttpSigTransport) Dereference(c context.Context, iri *url.URL) ([]byte, 
 	req.Header.Add("Accept-Charset", "utf-8")
 	req.Header.Add("Date", h.clock.Now().UTC().Format("Mon, 02 Jan 2006 15:04:05")+" GMT")
 	req.Header.Add("User-Agent", fmt.Sprintf("%s %s", h.appAgent, h.gofedAgent))
+	req.Header.Set("Host", iri.Host)
 	h.getSignerMu.Lock()
 	err = h.getSigner.SignRequest(h.privKey, h.pubKeyId, req, nil)
 	h.getSignerMu.Unlock()
@@ -146,6 +148,7 @@ func (h HttpSigTransport) Deliver(c context.Context, b []byte, to *url.URL) erro
 	req.Header.Add("Accept-Charset", "utf-8")
 	req.Header.Add("Date", h.clock.Now().UTC().Format("Mon, 02 Jan 2006 15:04:05")+" GMT")
 	req.Header.Add("User-Agent", fmt.Sprintf("%s %s", h.appAgent, h.gofedAgent))
+	req.Header.Set("Host", to.Host)
 	h.postSignerMu.Lock()
 	err = h.postSigner.SignRequest(h.privKey, h.pubKeyId, req, b)
 	h.postSignerMu.Unlock()


### PR DESCRIPTION
Mastodon refuses to accept signatures without the `host` header, and due to how httpsig works, we need to explicitly set the host header before we sign the request.