### PR TITLE
Fix #145: Change example domains to standards

### DIFF
--- a/astool/forgefed.jsonld
+++ b/astool/forgefed.jsonld
@@ -40,14 +40,14 @@
               "https://www.w3.org/ns/activitystreams",
               "https://forgefed.peers.community/ns"
             ],
-            "id": "https://example.dev/aviva/outbox/reBGo",
+            "id": "https://example.org/aviva/outbox/reBGo",
             "type": "Push",
-            "actor": "https://example.dev/aviva",
+            "actor": "https://example.org/aviva",
             "to": [
-              "https://example.dev/aviva/followers",
-              "https://example.dev/aviva/myproject",
-              "https://example.dev/aviva/myproject/team",
-              "https://example.dev/aviva/myproject/followers"
+              "https://example.org/aviva/followers",
+              "https://example.org/aviva/myproject",
+              "https://example.org/aviva/myproject/team",
+              "https://example.org/aviva/myproject/followers"
             ],
             "summary": "<p>Aviva pushed a commit to myproject</p>",
             "object": {
@@ -55,18 +55,18 @@
               "totalItems": 1,
               "items": [
                 {
-                  "id": "https://example.dev/aviva/myproject/commits/d96596230322716bd6f87a232a648ca9822a1c20",
+                  "id": "https://example.org/aviva/myproject/commits/d96596230322716bd6f87a232a648ca9822a1c20",
                   "type": "Commit",
-                  "attributedTo": "https://example.dev/aviva",
-                  "context": "https://example.dev/aviva/myproject",
+                  "attributedTo": "https://example.org/aviva",
+                  "context": "https://example.org/aviva/myproject",
                   "hash": "d96596230322716bd6f87a232a648ca9822a1c20",
                   "created": "2019-11-03T13:43:59Z",
                   "summary": "Provide hints in sign-up form fields"
                 }
               ]
             },
-            "target": "https://example.dev/aviva/myproject/branches/master",
-            "context": "https://example.dev/aviva/myproject"
+            "target": "https://example.org/aviva/myproject/branches/master",
+            "context": "https://example.org/aviva/myproject"
           }
         }
       ],
@@ -127,10 +127,10 @@
               "https://www.w3.org/ns/activitystreams",
               "https://forgefed.peers.community/ns"
             ],
-            "id": "https://example.dev/luke/myrepo/branches/master",
+            "id": "https://example.org/luke/myrepo/branches/master",
             "type": "Branch",
             "name": "master",
-            "context": "https://example.dev/luke/myrepo",
+            "context": "https://example.org/luke/myrepo",
             "ref": "refs/heads/master"
           }
         }
@@ -155,11 +155,11 @@
               "https://www.w3.org/ns/activitystreams",
               "https://forgefed.peers.community/ns"
             ],
-            "id": "https://example.dev/alice/myrepo/commits/109ec9a09c7df7fec775d2ba0b9d466e5643ec8c",
+            "id": "https://example.org/alice/myrepo/commits/109ec9a09c7df7fec775d2ba0b9d466e5643ec8c",
             "type": "Commit",
-            "context": "https://example.dev/alice/myrepo",
-            "attributedTo": "https://example.dev/bob",
-            "committedBy": "https://example.dev/alice",
+            "context": "https://example.org/alice/myrepo",
+            "attributedTo": "https://example.org/bob",
+            "committedBy": "https://example.org/alice",
             "hash": "109ec9a09c7df7fec775d2ba0b9d466e5643ec8c",
             "summary": "Add an installation script, fixes issue #89",
             "description": {
@@ -195,13 +195,13 @@
               "Relationship",
               "TicketDependency"
             ],
-            "id": "https://example.dev/ticket-deps/2342593",
-            "attributedTo": "https://example.dev/alice",
+            "id": "https://example.org/ticket-deps/2342593",
+            "attributedTo": "https://example.org/alice",
             "summary": "Alice's ticket depends on Bob's ticket",
             "published": "2019-07-11T12:34:56Z",
-            "subject": "https://example.dev/alice/myproj/issues/42",
+            "subject": "https://example.org/alice/myproj/issues/42",
             "relationship": "dependsOn",
-            "object": "https://dev.community/bob/coolproj/issues/85"
+            "object": "https://example.com/bob/coolproj/issues/85"
           }
         }
       ],
@@ -226,9 +226,9 @@
               "https://forgefed.peers.community/ns"
             ],
             "type": "Ticket",
-            "id": "https://example.dev/alice/myrepo/issues/42",
-            "context": "https://example.dev/alice/myrepo",
-            "attributedTo": "https://dev.community/bob",
+            "id": "https://example.org/alice/myrepo/issues/42",
+            "context": "https://example.org/alice/myrepo",
+            "attributedTo": "https://example.com/bob",
             "summary": "Nothing works!",
             "content": "<p>Please fix. <i>Everything</i> is broken!</p>",
             "mediaType": "text/html",
@@ -236,7 +236,7 @@
               "content": "Please fix. *Everything* is broken!",
               "mediaType": "text/markdown; variant=CommonMark"
             },
-            "assignedTo": "https://example.dev/alice",
+            "assignedTo": "https://example.org/alice",
             "isResolved": false
           }
         }
@@ -480,10 +480,10 @@
               "https://www.w3.org/ns/activitystreams",
               "https://forgefed.peers.community/ns"
             ],
-            "id": "https://example.dev/alice/myrepo/commits/109ec9a09c7df7fec775d2ba0b9d466e5643ec8c",
+            "id": "https://example.org/alice/myrepo/commits/109ec9a09c7df7fec775d2ba0b9d466e5643ec8c",
             "type": "Commit",
-            "context": "https://example.dev/alice/myrepo",
-            "attributedTo": "https://example.dev/bob",
+            "context": "https://example.org/alice/myrepo",
+            "attributedTo": "https://example.org/bob",
             "hash": "109ec9a09c7df7fec775d2ba0b9d466e5643ec8c",
             "created": "2019-07-11T12:34:56Z",
             "summary": "Add an installation script, fixes issue #89",
@@ -671,10 +671,10 @@
               "https://www.w3.org/ns/activitystreams",
               "https://forgefed.peers.community/ns"
             ],
-            "id": "https://example.dev/luke/myrepo/branches/master",
+            "id": "https://example.org/luke/myrepo/branches/master",
             "type": "Branch",
             "name": "master",
-            "context": "https://example.dev/luke/myrepo",
+            "context": "https://example.org/luke/myrepo",
             "ref": "refs/heads/master"
           }
         }

--- a/streams/impl/forgefed/type_branch/gen_type_forgefed_branch.go
+++ b/streams/impl/forgefed/type_branch/gen_type_forgefed_branch.go
@@ -17,8 +17,8 @@ import (
 //       "https://www.w3.org/ns/activitystreams",
 //       "https://forgefed.peers.community/ns"
 //     ],
-//     "context": "https://example.dev/luke/myrepo",
-//     "id": "https://example.dev/luke/myrepo/branches/master",
+//     "context": "https://example.org/luke/myrepo",
+//     "id": "https://example.org/luke/myrepo/branches/master",
 //     "name": "master",
 //     "ref": "refs/heads/master",
 //     "type": "Branch"

--- a/streams/impl/forgefed/type_commit/gen_type_forgefed_commit.go
+++ b/streams/impl/forgefed/type_commit/gen_type_forgefed_commit.go
@@ -19,17 +19,17 @@ import (
 //       "https://www.w3.org/ns/activitystreams",
 //       "https://forgefed.peers.community/ns"
 //     ],
-//     "attributedTo": "https://example.dev/bob",
+//     "attributedTo": "https://example.org/bob",
 //     "committed": "2019-07-26T23:45:01Z",
-//     "committedBy": "https://example.dev/alice",
-//     "context": "https://example.dev/alice/myrepo",
+//     "committedBy": "https://example.org/alice",
+//     "context": "https://example.org/alice/myrepo",
 //     "created": "2019-07-11T12:34:56Z",
 //     "description": {
 //       "content": "It's about time people can install on their computers!",
 //       "mediaType": "text/plain"
 //     },
 //     "hash": "109ec9a09c7df7fec775d2ba0b9d466e5643ec8c",
-//     "id": "https://example.dev/alice/myrepo/commits/109ec9a09c7df7fec775d2ba0b9d466e5643ec8c",
+//     "id": "https://example.org/alice/myrepo/commits/109ec9a09c7df7fec775d2ba0b9d466e5643ec8c",
 //     "summary": "Add an installation script, fixes issue #89",
 //     "type": "Commit"
 //   }

--- a/streams/impl/forgefed/type_push/gen_type_forgefed_push.go
+++ b/streams/impl/forgefed/type_push/gen_type_forgefed_push.go
@@ -15,17 +15,17 @@ import (
 //       "https://www.w3.org/ns/activitystreams",
 //       "https://forgefed.peers.community/ns"
 //     ],
-//     "actor": "https://example.dev/aviva",
-//     "context": "https://example.dev/aviva/myproject",
-//     "id": "https://example.dev/aviva/outbox/reBGo",
+//     "actor": "https://example.org/aviva",
+//     "context": "https://example.org/aviva/myproject",
+//     "id": "https://example.org/aviva/outbox/reBGo",
 //     "object": {
 //       "items": [
 //         {
-//           "attributedTo": "https://example.dev/aviva",
-//           "context": "https://example.dev/aviva/myproject",
+//           "attributedTo": "https://example.org/aviva",
+//           "context": "https://example.org/aviva/myproject",
 //           "created": "2019-11-03T13:43:59Z",
 //           "hash": "d96596230322716bd6f87a232a648ca9822a1c20",
-//           "id": "https://example.dev/aviva/myproject/commits/d96596230322716bd6f87a232a648ca9822a1c20",
+//           "id": "https://example.org/aviva/myproject/commits/d96596230322716bd6f87a232a648ca9822a1c20",
 //           "summary": "Provide hints in sign-up form fields",
 //           "type": "Commit"
 //         }
@@ -35,12 +35,12 @@ import (
 //     },
 //     "summary": "\u003cp\u003eAviva pushed a commit to
 // myproject\u003c/p\u003e",
-//     "target": "https://example.dev/aviva/myproject/branches/master",
+//     "target": "https://example.org/aviva/myproject/branches/master",
 //     "to": [
-//       "https://example.dev/aviva/followers",
-//       "https://example.dev/aviva/myproject",
-//       "https://example.dev/aviva/myproject/team",
-//       "https://example.dev/aviva/myproject/followers"
+//       "https://example.org/aviva/followers",
+//       "https://example.org/aviva/myproject",
+//       "https://example.org/aviva/myproject/team",
+//       "https://example.org/aviva/myproject/followers"
 //     ],
 //     "type": "Push"
 //   }

--- a/streams/impl/forgefed/type_ticket/gen_type_forgefed_ticket.go
+++ b/streams/impl/forgefed/type_ticket/gen_type_forgefed_ticket.go
@@ -17,12 +17,12 @@ import (
 //       "https://www.w3.org/ns/activitystreams",
 //       "https://forgefed.peers.community/ns"
 //     ],
-//     "assignedTo": "https://example.dev/alice",
-//     "attributedTo": "https://dev.community/bob",
+//     "assignedTo": "https://example.org/alice",
+//     "attributedTo": "https://example.com/bob",
 //     "content": "\u003cp\u003ePlease fix.
 // \u003ci\u003eEverything\u003c/i\u003e is broken!\u003c/p\u003e",
-//     "context": "https://example.dev/alice/myrepo",
-//     "id": "https://example.dev/alice/myrepo/issues/42",
+//     "context": "https://example.org/alice/myrepo",
+//     "id": "https://example.org/alice/myrepo/issues/42",
 //     "isResolved": false,
 //     "mediaType": "text/html",
 //     "source": {

--- a/streams/impl/forgefed/type_ticketdependency/gen_type_forgefed_ticketdependency.go
+++ b/streams/impl/forgefed/type_ticketdependency/gen_type_forgefed_ticketdependency.go
@@ -18,12 +18,12 @@ import (
 //       "https://www.w3.org/ns/activitystreams",
 //       "https://forgefed.peers.community/ns"
 //     ],
-//     "attributedTo": "https://example.dev/alice",
-//     "id": "https://example.dev/ticket-deps/2342593",
-//     "object": "https://dev.community/bob/coolproj/issues/85",
+//     "attributedTo": "https://example.org/alice",
+//     "id": "https://example.org/ticket-deps/2342593",
+//     "object": "https://example.com/bob/coolproj/issues/85",
 //     "published": "2019-07-11T12:34:56Z",
 //     "relationship": "dependsOn",
-//     "subject": "https://example.dev/alice/myproj/issues/42",
+//     "subject": "https://example.org/alice/myproj/issues/42",
 //     "summary": "Alice's ticket depends on Bob's ticket",
 //     "type": [
 //       "Relationship",

--- a/streams/vocab/gen_property_forgefed_description_interface.go
+++ b/streams/vocab/gen_property_forgefed_description_interface.go
@@ -14,15 +14,15 @@ import "net/url"
 //       "https://www.w3.org/ns/activitystreams",
 //       "https://forgefed.peers.community/ns"
 //     ],
-//     "attributedTo": "https://example.dev/bob",
-//     "context": "https://example.dev/alice/myrepo",
+//     "attributedTo": "https://example.org/bob",
+//     "context": "https://example.org/alice/myrepo",
 //     "created": "2019-07-11T12:34:56Z",
 //     "description": {
 //       "content": "It's about time people can install on their computers!",
 //       "mediaType": "text/plain"
 //     },
 //     "hash": "109ec9a09c7df7fec775d2ba0b9d466e5643ec8c",
-//     "id": "https://example.dev/alice/myrepo/commits/109ec9a09c7df7fec775d2ba0b9d466e5643ec8c",
+//     "id": "https://example.org/alice/myrepo/commits/109ec9a09c7df7fec775d2ba0b9d466e5643ec8c",
 //     "summary": "Add an installation script, fixes issue #89",
 //     "type": "Commit"
 //   }

--- a/streams/vocab/gen_property_forgefed_ref_interface.go
+++ b/streams/vocab/gen_property_forgefed_ref_interface.go
@@ -13,8 +13,8 @@ import "net/url"
 //       "https://www.w3.org/ns/activitystreams",
 //       "https://forgefed.peers.community/ns"
 //     ],
-//     "context": "https://example.dev/luke/myrepo",
-//     "id": "https://example.dev/luke/myrepo/branches/master",
+//     "context": "https://example.org/luke/myrepo",
+//     "id": "https://example.org/luke/myrepo/branches/master",
 //     "name": "master",
 //     "ref": "refs/heads/master",
 //     "type": "Branch"

--- a/streams/vocab/gen_type_forgefed_branch_interface.go
+++ b/streams/vocab/gen_type_forgefed_branch_interface.go
@@ -11,8 +11,8 @@ package vocab
 //       "https://www.w3.org/ns/activitystreams",
 //       "https://forgefed.peers.community/ns"
 //     ],
-//     "context": "https://example.dev/luke/myrepo",
-//     "id": "https://example.dev/luke/myrepo/branches/master",
+//     "context": "https://example.org/luke/myrepo",
+//     "id": "https://example.org/luke/myrepo/branches/master",
 //     "name": "master",
 //     "ref": "refs/heads/master",
 //     "type": "Branch"

--- a/streams/vocab/gen_type_forgefed_commit_interface.go
+++ b/streams/vocab/gen_type_forgefed_commit_interface.go
@@ -13,17 +13,17 @@ package vocab
 //       "https://www.w3.org/ns/activitystreams",
 //       "https://forgefed.peers.community/ns"
 //     ],
-//     "attributedTo": "https://example.dev/bob",
+//     "attributedTo": "https://example.org/bob",
 //     "committed": "2019-07-26T23:45:01Z",
-//     "committedBy": "https://example.dev/alice",
-//     "context": "https://example.dev/alice/myrepo",
+//     "committedBy": "https://example.org/alice",
+//     "context": "https://example.org/alice/myrepo",
 //     "created": "2019-07-11T12:34:56Z",
 //     "description": {
 //       "content": "It's about time people can install on their computers!",
 //       "mediaType": "text/plain"
 //     },
 //     "hash": "109ec9a09c7df7fec775d2ba0b9d466e5643ec8c",
-//     "id": "https://example.dev/alice/myrepo/commits/109ec9a09c7df7fec775d2ba0b9d466e5643ec8c",
+//     "id": "https://example.org/alice/myrepo/commits/109ec9a09c7df7fec775d2ba0b9d466e5643ec8c",
 //     "summary": "Add an installation script, fixes issue #89",
 //     "type": "Commit"
 //   }

--- a/streams/vocab/gen_type_forgefed_push_interface.go
+++ b/streams/vocab/gen_type_forgefed_push_interface.go
@@ -9,17 +9,17 @@ package vocab
 //       "https://www.w3.org/ns/activitystreams",
 //       "https://forgefed.peers.community/ns"
 //     ],
-//     "actor": "https://example.dev/aviva",
-//     "context": "https://example.dev/aviva/myproject",
-//     "id": "https://example.dev/aviva/outbox/reBGo",
+//     "actor": "https://example.org/aviva",
+//     "context": "https://example.org/aviva/myproject",
+//     "id": "https://example.org/aviva/outbox/reBGo",
 //     "object": {
 //       "items": [
 //         {
-//           "attributedTo": "https://example.dev/aviva",
-//           "context": "https://example.dev/aviva/myproject",
+//           "attributedTo": "https://example.org/aviva",
+//           "context": "https://example.org/aviva/myproject",
 //           "created": "2019-11-03T13:43:59Z",
 //           "hash": "d96596230322716bd6f87a232a648ca9822a1c20",
-//           "id": "https://example.dev/aviva/myproject/commits/d96596230322716bd6f87a232a648ca9822a1c20",
+//           "id": "https://example.org/aviva/myproject/commits/d96596230322716bd6f87a232a648ca9822a1c20",
 //           "summary": "Provide hints in sign-up form fields",
 //           "type": "Commit"
 //         }
@@ -29,12 +29,12 @@ package vocab
 //     },
 //     "summary": "\u003cp\u003eAviva pushed a commit to
 // myproject\u003c/p\u003e",
-//     "target": "https://example.dev/aviva/myproject/branches/master",
+//     "target": "https://example.org/aviva/myproject/branches/master",
 //     "to": [
-//       "https://example.dev/aviva/followers",
-//       "https://example.dev/aviva/myproject",
-//       "https://example.dev/aviva/myproject/team",
-//       "https://example.dev/aviva/myproject/followers"
+//       "https://example.org/aviva/followers",
+//       "https://example.org/aviva/myproject",
+//       "https://example.org/aviva/myproject/team",
+//       "https://example.org/aviva/myproject/followers"
 //     ],
 //     "type": "Push"
 //   }

--- a/streams/vocab/gen_type_forgefed_ticket_interface.go
+++ b/streams/vocab/gen_type_forgefed_ticket_interface.go
@@ -11,12 +11,12 @@ package vocab
 //       "https://www.w3.org/ns/activitystreams",
 //       "https://forgefed.peers.community/ns"
 //     ],
-//     "assignedTo": "https://example.dev/alice",
-//     "attributedTo": "https://dev.community/bob",
+//     "assignedTo": "https://example.org/alice",
+//     "attributedTo": "https://example.com/bob",
 //     "content": "\u003cp\u003ePlease fix.
 // \u003ci\u003eEverything\u003c/i\u003e is broken!\u003c/p\u003e",
-//     "context": "https://example.dev/alice/myrepo",
-//     "id": "https://example.dev/alice/myrepo/issues/42",
+//     "context": "https://example.org/alice/myrepo",
+//     "id": "https://example.org/alice/myrepo/issues/42",
 //     "isResolved": false,
 //     "mediaType": "text/html",
 //     "source": {

--- a/streams/vocab/gen_type_forgefed_ticketdependency_interface.go
+++ b/streams/vocab/gen_type_forgefed_ticketdependency_interface.go
@@ -12,12 +12,12 @@ package vocab
 //       "https://www.w3.org/ns/activitystreams",
 //       "https://forgefed.peers.community/ns"
 //     ],
-//     "attributedTo": "https://example.dev/alice",
-//     "id": "https://example.dev/ticket-deps/2342593",
-//     "object": "https://dev.community/bob/coolproj/issues/85",
+//     "attributedTo": "https://example.org/alice",
+//     "id": "https://example.org/ticket-deps/2342593",
+//     "object": "https://example.com/bob/coolproj/issues/85",
 //     "published": "2019-07-11T12:34:56Z",
 //     "relationship": "dependsOn",
-//     "subject": "https://example.dev/alice/myproj/issues/42",
+//     "subject": "https://example.org/alice/myproj/issues/42",
 //     "summary": "Alice's ticket depends on Bob's ticket",
 //     "type": [
 //       "Relationship",


### PR DESCRIPTION
This is just a search/replace of example.dev to example.org and dev.community to example.com.