### PR TITLE
Add GitHub build workflow, remove TravisCI config

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,29 @@
+name: build
+on: [push, pull_request]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        go-version: [~1.15, ^1]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    env:
+      GO111MODULE: "on"
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go-version }}
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Download Go modules
+        run: go mod download
+
+      - name: Build
+        run: go build -v ./...
+
+      - name: Test
+        run: go test ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,0 @@
-language: go
-go:
-  - 1.15

--- a/README.md
+++ b/README.md
@@ -96,8 +96,8 @@ libraries.
 Thanks to those who have been early adopters with v0 and/or provided early
 feedback.
 
-[Build-Status-Image]: https://travis-ci.org/go-fed/activity.svg?branch=master
-[Build-Status-Url]: https://travis-ci.org/go-fed/activity
+[Build-Status-Image]: https://github.com/go-fed/activity/workflows/build/badge.svg
+[Build-Status-Url]: https://github.com/go-fed/activity/actions
 [Go-Reference-Image]: https://pkg.go.dev/badge/github.com/go-fed/activity
 [Go-Reference-Url]: https://pkg.go.dev/github.com/go-fed/activity
 [Go-Report-Card-Image]: https://goreportcard.com/badge/github.com/go-fed/activity


### PR DESCRIPTION
Switches CI builds from the mostly defunct TravisCI to GitHub workflows.

Note: this uncovered a failing test, which is why the newly introduced build workflow currently also fails.